### PR TITLE
Update FlashlightShakeToggle.java

### DIFF
--- a/app/src/main/java/android/nachiketa/flashlight/FlashlightShakeToggle.java
+++ b/app/src/main/java/android/nachiketa/flashlight/FlashlightShakeToggle.java
@@ -12,6 +12,7 @@ import android.hardware.camera2.CameraManager;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.Vibrator;
+import android.util.Log;
 
 public class FlashlightShakeToggle extends Service implements SensorEventListener {
 
@@ -20,6 +21,7 @@ public class FlashlightShakeToggle extends Service implements SensorEventListene
     public static final int MIN_TIME_BETWEEN_SHAKES = 1000;
     private long lastShakeTime = 0;
     private boolean isFlashlightOn = false;
+    Float shakeThreshold = null;
 
     public FlashlightShakeToggle() {
 
@@ -43,16 +45,9 @@ public class FlashlightShakeToggle extends Service implements SensorEventListene
 
     @Override
     public void onSensorChanged(SensorEvent event) {
-        Float shakeThreshold;
-        try {
-            shakeThreshold = Float.parseFloat(AndroidReadWrite.loadFile(getApplicationContext(), "settings.txt"));
-        } catch (Exception ex) {
-            AndroidReadWrite.saveFile(getApplicationContext(), "settings.txt", 10.2f + "");
-            shakeThreshold = 10.2f;
-            ex.getMessage();
-        }
 
         if (event.sensor.getType() == Sensor.TYPE_ACCELEROMETER) {
+
             long curTime = System.currentTimeMillis();
             if ((curTime - lastShakeTime) > MIN_TIME_BETWEEN_SHAKES) {
 
@@ -64,14 +59,27 @@ public class FlashlightShakeToggle extends Service implements SensorEventListene
                         Math.pow(y, 2) +
                         Math.pow(z, 2)) - SensorManager.GRAVITY_EARTH;
 
-                if (acceleration > shakeThreshold) {
-                    lastShakeTime = curTime;
-                    if (!isFlashlightOn) {
-                        torchToggle("on");
-                        isFlashlightOn = true;
-                    } else {
-                        torchToggle("off");
-                        isFlashlightOn = false;
+                if (acceleration > 3f){
+
+                    Log.i("loadFile", "Acceleration is: " + acceleration);
+
+                    try {
+                        shakeThreshold = Float.parseFloat(AndroidReadWrite.loadFile(getApplicationContext(), "settings.txt"));
+                    } catch (Exception ex) {
+                        AndroidReadWrite.saveFile(getApplicationContext(), "settings.txt", 10.2f + "");
+                        shakeThreshold = 10.2f;
+                        ex.getMessage();
+                    }
+
+                    if (acceleration > shakeThreshold) {
+                        lastShakeTime = curTime;
+                        if (!isFlashlightOn) {
+                            torchToggle("on");
+                            isFlashlightOn = true;
+                        } else {
+                            torchToggle("off");
+                            isFlashlightOn = false;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I liked this project and corrected it a bit for myself. Maybe it can be useful for main branch as well.

Basically i changed part method "onSensorChanged" to fire reading settings only when sensor type is accelerometer and only when acceleration exceeds 3f treshold. Otherwise settings file read is fired too many times unnecessarily.